### PR TITLE
Export InputSpinner via forwardRef

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ import InputSpinner from "./InputSpinner";
 import {getSkin} from "./Skins";
 
 // Export
-export default (props) => {
+export default React.forwardRef((props, ref) => {
 	const skinProps = getSkin(props.skin, props);
 	const finalProps = {...props, ...skinProps};
-	return <InputSpinner {...finalProps} />;
-};
+	return <InputSpinner {...finalProps} ref={ref} />;
+});


### PR DESCRIPTION
This addresses the error: `Function components cannot be given refs.` that arises from using a ref with InputSpinner.